### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,8 @@ jobs:
     name: Release Approval
     needs: [setup_and_build, details]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: release-approval
       url: https://github.com/${{ env.OWNER }}/${{ env.PACKAGE_NAME }}/releases


### PR DESCRIPTION
Potential fix for [https://github.com/JohanLi233/viby/security/code-scanning/5](https://github.com/JohanLi233/viby/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `release_approval` job. Since this job only displays release information and does not perform any write operations, we will set the permissions to `contents: read`. This ensures that the job has the minimal permissions required to execute its steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
