### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,8 @@ jobs:
   setup_and_build:
     needs: [details, check_pypi]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Potential fix for [https://github.com/JohanLi233/viby/security/code-scanning/4](https://github.com/JohanLi233/viby/security/code-scanning/4)

To fix the issue, we need to explicitly define the permissions for the `setup_and_build` job. Based on the actions performed in this job, such as checking out the repository, setting up Python, and building the project, it only requires `contents: read` permissions. This ensures that the job has the minimal permissions necessary to function correctly.

The fix involves adding a `permissions` block to the `setup_and_build` job, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
