### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ env:
 jobs:
   details:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       new_version: ${{ steps.release.outputs.new_version }}
       suffix: ${{ steps.release.outputs.suffix }}


### PR DESCRIPTION
Potential fix for [https://github.com/JohanLi233/viby/security/code-scanning/1](https://github.com/JohanLi233/viby/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `details` job, specifying the minimal required permissions. Since the `details` job only reads tag information and outputs it, it only requires `contents: read`. This change ensures that the job does not inherit unnecessary write permissions from the repository or organization.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
