### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/JohanLi233/viby/security/code-scanning/2](https://github.com/JohanLi233/viby/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since this workflow is a basic CI pipeline for running Python tests, it only requires read access to the repository contents. We will set `contents: read` as the minimal permission required. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
