### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,9 @@
 name: release
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     tags:
@@ -15,6 +19,8 @@ env:
 jobs:
   details:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       new_version: ${{ steps.release.outputs.new_version }}
       suffix: ${{ steps.release.outputs.suffix }}
@@ -69,6 +75,8 @@ jobs:
   setup_and_build:
     needs: [details, check_pypi]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Potential fix for [https://github.com/JohanLi233/viby/security/code-scanning/3](https://github.com/JohanLi233/viby/security/code-scanning/3)

To fix the issue, we will:
1. Add a `permissions` block at the root level of the workflow to define the least privileges required for all jobs.
2. Override the root-level permissions for specific jobs if they require additional permissions.
3. Analyze the workflow to determine the minimal permissions required:
   - `contents: read` for accessing repository contents.
   - `contents: write` for modifying `pyproject.toml` and uploading artifacts.
   - `packages: read` for fetching information from PyPI.
   - `actions: read` for using GitHub Actions features like `actions/checkout`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
